### PR TITLE
Added LREC 2026 semantic tagger paper

### DIFF
--- a/src/_data/publications.bib
+++ b/src/_data/publications.bib
@@ -35,3 +35,17 @@
   pages={1320--1326},
   year={2025}
 }
+
+@inproceedings{moore-etal-2026-creating,
+  title = {Creating a Hybrid Rule and Neural Network Based Semantic Tagger Using Silver Standard Data: The PyMUSAS Framework for Multilingual Semantic Annotation},
+  author = {Moore, Andrew and Rayson, Paul and Archer, Dawn and Czerniak, Tim and Knight, Dawn and Lal, Daisy Monika and Donnchadha, Gearóid Ó and Meachair, Mícheál J. Ó and Piao, Scott and Dhonnchadha, Elaine Uí and Vuorinen, Johanna and Yabo, Yan and Yang, Xiaobin},
+  booktitle = {Proceedings of the Fifteenth Language Resources and Evaluation Conference (LREC 2026)},
+  month = {May},
+  year = {2026},
+  pages = {11822--11833},
+  address = {Palma, Mallorca, Spain},
+  publisher = {European Language Resources Association (ELRA)},
+  editor = {Piperidis, Stelios and Bel, Núria and van den Heuvel, Henk and Ide, Nancy and Krek, Simon and Toral, Antonio},
+  doi = {10.63317/4ngkupgnrbgc},
+  abstract = {Word Sense Disambiguation (WSD) has been widely evaluated using the semantic frameworks of WordNet, BabelNet, and the Oxford Dictionary of English. However, for the UCREL Semantic Analysis System (USAS) framework, no open extensive evaluation has been performed beyond lexical coverage or single language evaluation. In this work, we perform the largest semantic tagging evaluation of the rule based system that uses the lexical resources in the USAS framework covering five different languages using four existing datasets and one novel Chinese dataset. We create a new silver labelled English dataset, to overcome the lack of manually tagged training data, that we train and evaluate various mono and multilingual neural models in both mono and cross-lingual evaluation setups with comparisons to their rule based counterparts, and show how a rule based system can be enhanced with a neural network model. The resulting neural network models, including the data they were trained on, the Chinese evaluation dataset, and all of the code will be released as open resources.}
+}


### PR DESCRIPTION
Added LREC 2026 semantic tagger paper to the publications.bib file as it has used Hex of which we acknowledge this within the acknowledgement section of the paper.